### PR TITLE
Decoupling tests from analyze_log_stream

### DIFF
--- a/src/alogamous/analyzer.py
+++ b/src/alogamous/analyzer.py
@@ -17,4 +17,4 @@ def analyze_log_stream(analyzers, in_stream, out_stream):
             analyzer.read_log_line(line.rstrip())
     for analyzer in analyzers:
         analyzer.report(out_stream)
-        # out_stream.write("\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n")
+        out_stream.write("\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n")

--- a/tests/analyze_log_stream_test.py
+++ b/tests/analyze_log_stream_test.py
@@ -1,3 +1,5 @@
+import io
+
 from alogamous import analyzer
 
 
@@ -17,14 +19,14 @@ class TestAnalyzer2(analyzer.Analyzer):
         pass
 
 
-# def test_analyze_log_stream():
-#     in_stream = io.StringIO("""line1
-#             line2
-#             line3""")
-#     out_stream = io.StringIO()
-#
-#     analyzer.analyze_log_stream([TestAnalyzer1(), TestAnalyzer2()], in_stream, out_stream)
-#     assert (
-#         out_stream.getvalue()
-#         == "\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n"
-#     )
+def test_analyze_log_stream():
+    in_stream = io.StringIO("""line1
+            line2
+            line3""")
+    out_stream = io.StringIO()
+
+    analyzer.analyze_log_stream([TestAnalyzer1(), TestAnalyzer2()], in_stream, out_stream)
+    assert (
+        out_stream.getvalue()
+        == "\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n"
+    )

--- a/tests/flag_duplicate_log_messages_test.py
+++ b/tests/flag_duplicate_log_messages_test.py
@@ -1,19 +1,27 @@
 import io
 
-from alogamous import analyzer, flag_duplicate_log_messages
+from alogamous import flag_duplicate_log_messages
 
 
 def test_flag_duplicate_log_messages():
+    flagger = flag_duplicate_log_messages.FlagDuplicateLogMessages()
     in_stream = io.StringIO("""Date - root - INFO - log message 1
         Date - root - WARNING - log message 2
         Date - root - WARNING - log message 1""")
     out_stream = io.StringIO()
-    analyzer.analyze_log_stream([flag_duplicate_log_messages.FlagDuplicateLogMessages()], in_stream, out_stream)
+    for line in in_stream:
+        flagger.read_log_line(line)
+    flagger.report(out_stream)
     assert out_stream.getvalue() == """Duplicate Log Messages:\nlog message 1\n"""
 
+
+def test_flag_duplicate_log_messages_no_duplicates():
+    flagger = flag_duplicate_log_messages.FlagDuplicateLogMessages()
     in_stream = io.StringIO("""Date - root - INFO - log message 1
         Date - root - WARNING - log message 2
         Date - root - WARNING - log message 3""")
     out_stream = io.StringIO()
-    analyzer.analyze_log_stream([flag_duplicate_log_messages.FlagDuplicateLogMessages()], in_stream, out_stream)
+    for line in in_stream:
+        flagger.read_log_line(line)
+    flagger.report(out_stream)
     assert out_stream.getvalue() == """No duplicate log messages\n"""

--- a/tests/test_error_counter.py
+++ b/tests/test_error_counter.py
@@ -1,29 +1,34 @@
 import io
 
-from alogamous import analyzer, error_counter_analyzer
+from alogamous import error_counter_analyzer
 
 
 def test_error_counter():
-    in_stream = io.StringIO("""line1
-        blahblahERRORblah
-        oh_no_another_ERROR""")
+    counter = error_counter_analyzer.ErrorCounterAnalyzer()
+    in_stream = io.StringIO(
+        """2024-06-20 17:16:03,660 - root - ERROR - Caught exception N/A.
+2024-06-20 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed connector NoneType: None"""
+    )
     out_stream = io.StringIO()
-    analyzer.analyze_log_stream([error_counter_analyzer.ErrorCounterAnalyzer()], in_stream, out_stream)
+    for line in in_stream:
+        counter.read_log_line(line)
+    counter.report(out_stream)
     assert out_stream.getvalue().strip() == "Number of error lines: 2"
 
 
 def test_no_errors():
-    in_stream = io.StringIO("""good
-    nice
-    very good
-    """)
+    counter = error_counter_analyzer.ErrorCounterAnalyzer()
+    in_stream = io.StringIO("""2024-06-20 17:17:04,278 - root - INFO - Updating prices
+2024-06-20 17:24:34,091 - root - INFO - Closing client connection.""")
     out_stream = io.StringIO()
-    analyzer.analyze_log_stream([error_counter_analyzer.ErrorCounterAnalyzer()], in_stream, out_stream)
+    for line in in_stream:
+        counter.read_log_line(line)
+    counter.report(out_stream)
     assert out_stream.getvalue().strip() == "Number of error lines: 0"
 
 
 def test_no_input_lines():
-    in_stream = io.StringIO("")
+    counter = error_counter_analyzer.ErrorCounterAnalyzer()
     out_stream = io.StringIO()
-    analyzer.analyze_log_stream([error_counter_analyzer.ErrorCounterAnalyzer()], in_stream, out_stream)
+    counter.report(out_stream)
     assert out_stream.getvalue().strip() == "Number of error lines: 0"

--- a/tests/warning_analyzer_test.py
+++ b/tests/warning_analyzer_test.py
@@ -1,9 +1,10 @@
 import io
 
-from alogamous import analyzer, warning_analyzer
+from alogamous import warning_analyzer
 
 
 def test_warning_count():
+    counter = warning_analyzer.WarningAnalyzer()
     in_stream = io.StringIO("""2024-06-20 11:00:18,185 - root - INFO - Kafka reading from start of day 2024-06-20 05:00:00+00:00 on topic internal from kafka.servers:9092
 2024-06-20 11:00:19,328 - root - INFO - Kafka source starting for topic internal at current offset 7924032 end offset 7928950 on servers kafka.servers:9092
 2024-06-20 11:00:22,329 - root - INFO - Kafka topic internal is caught up at offset 7928949
@@ -13,5 +14,7 @@ def test_warning_count():
 2024-06-20 11:40:43,527 - root - WARNING - instrument not found for sedol BYP321337
 2024-06-20 17:25:08,029 - root - ERROR - Exception in message handler <bound method TrackingService.method of <app.tracking_service.TrackingService object at 0x7feba0d0>> TrackingService.on_order_change() missing 1 required positional argument: 'order_identifier'""")
     out_stream = io.StringIO()
-    analyzer.analyze_log_stream([warning_analyzer.WarningAnalyzer()], in_stream, out_stream)
+    for line in in_stream:
+        counter.read_log_line(line)
+    counter.report(out_stream)
     assert out_stream.getvalue() == "\n2 Warnings were detected."


### PR DESCRIPTION
Closes #58

Making tests use the `read_log_line` and `report` methods instead of `analyze_log_stream` method