### PR TITLE
Making format analyzer not flag stack traces

### DIFF
--- a/data/test_output_file.txt
+++ b/data/test_output_file.txt
@@ -1,151 +1,135 @@
-====================================================
+Number of error lines: 22
+
+Duplicate Log Messages:
 STARTING Tracking service
-    Start time: 2024-06-20 09:00:00.001550+00:00
-    Version: 2729a
-    Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+20 05:00:00+00:00 on topic internal from kafka.servers:9092
+Could not find instrument for ric UTU.T, using provided identifier 3
+instrument not found for sedol OIN38378
+instrument not found for ric RUE.ST
+prometheus client http server running
+Closing client connection.
+Could not find instrument for ric YT.ATS, using provided identifier 1
+instrument not found for sedol DHI7337
+Could not find instrument for sedol UY29387, trying ric RUE.ST
+instrument not found for sedol BYP321337
+Updating subscribed topics to: frozenset({'internal'})
+20 09:00:00.001550+00:00
+market hours frequency
+Caught exception N/A. Message: Unclosed client session NoneType: None
+Version: 2729a
+Could not find instrument for sedol BYP321337, trying ric YT.ATS
+instrument not found for ric UYU.T
+Caught exception N/A. Message: Unclosed connector NoneType: None
+Updating prices
+Could not find instrument for sedol RZZZZ2, trying ric UYU.T
 ====================================================
-2024-06-20 11:00:17,983 - root - INFO - Adding subscription for pid None
-2024-06-20 11:00:18,115 - root - INFO - Initialized Influx DB Client to host
-2024-06-20 11:00:18,115 - root - INFO - Scheduling Error Handler in 150.0 seconds
-2024-06-20 11:00:18,116 - root - INFO - prometheus client http server running
-2024-06-20 11:00:18,172 - root - INFO - Initialized prometheus server.
-2024-06-20 11:00:18,172 - root - INFO - reading messages from 2024-06-20
-2024-06-20 11:00:18,172 - aiokafka.consumer.subscription_state - INFO - Updating subscribed topics to: frozenset({'internal'})
-2024-06-20 11:00:18,185 - root - INFO - Kafka reading from start of day 2024-06-20 05:00:00+00:00 on topic internal from kafka.servers:9092
-2024-06-20 11:00:19,328 - root - INFO - Kafka source starting for topic internal at current offset 7924032 end offset 7928950 on servers kafka.servers:9092
-2024-06-20 11:00:22,329 - root - INFO - Kafka topic internal is caught up at offset 7928949
-2024-06-20 11:00:22,329 - root - INFO - setting influx write rate to pre-market hours frequency
-2024-06-20 11:00:22,329 - root - INFO - Tracking service is caught up
-2024-06-20 11:40:43,527 - root - WARNING - instrument not found for sedol BYP321337
-2024-06-20 11:40:43,527 - root - WARNING - Could not find instrument for sedol BYP321337, trying ric YT.ATS
-2024-06-20 11:40:43,527 - root - WARNING - instrument not found for ric YT.ATS
-2024-06-20 11:40:43,527 - root - WARNING - Could not find instrument for ric YT.ATS, using provided identifier 1
-2024-06-20 11:40:43,527 - root - WARNING - instrument not found for sedol DHI7337
-2024-06-20 11:40:43,527 - root - WARNING - Could not find instrument for sedol DHI7337, trying ric YT.ATS
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric JPQ.CC
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric JPQ.CC, using provided identifier 2
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for sedol RZZZZ2
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for sedol RZZZZ2, trying ric UYU.T
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric UYU.T
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric UTU.T, using provided identifier 3
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for sedol OIN38378
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for sedol OIN38378, trying ric 837.RIJ
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric 837.RIJ
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric 837.RIJ, using provided identifier 4
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for sedol UY29387
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for sedol UY29387, trying ric RUE.ST
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric RUE.ST
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric RUE.ST, using provided identifier 5
-2024-06-20 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-20 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed connector NoneType: None
-2024-06-20 17:17:04,278 - root - INFO - Updating prices
-2024-06-20 17:24:34,091 - root - INFO - Closing client connection.
-2024-06-20 17:24:34,092 - root - INFO - Client (0)ui-tracking_service Closed
-2024-06-20 17:25:08,029 - root - ERROR - Exception in message handler <bound method TrackingService.method of <app.tracking_service.TrackingService object at 0x7feba0d0>> TrackingService.on_order_change() missing 1 required positional argument: 'order_identifier'
-Hello I am a bad log line
+Could not find instrument for sedol DHI7337, trying ric YT.ATS
+instrument not found for ric JPQ.CC
+20
+Scheduling Error Handler in 150.0 seconds
+instrument not found for sedol UY29387
+Exception in message handler <bound method TrackingService.method of <app.tracking_service.TrackingService object at 0x7feba0d0>> TrackingService.on_order_change() missing 1 required positional argument: 'order_identifier'
+instrument not found for ric YT.ATS
+version', '2729a']
+Kafka source starting for topic internal at current offset 7924032 end offset 7928950 on servers kafka.servers:9092
+Could not find instrument for ric RUE.ST, using provided identifier 5
+Initialized prometheus server.
+Adding subscription for pid None
+Kafka topic internal is caught up at offset 7928949
+Could not find instrument for sedol OIN38378, trying ric 837.RIJ
+instrument not found for sedol RZZZZ2
+Could not find instrument for ric 837.RIJ, using provided identifier 4
+Tracking service is caught up
+tracking_service Closed
+instrument not found for ric 837.RIJ
+Could not find instrument for ric JPQ.CC, using provided identifier 2
+Initialized Influx DB Client to host
+
+Number of log lines: 151
+
+Lines that do not conform to log format:
+- Hello I am a bad log line
+
+Lines that are part of the startup header:
+- STARTING Tracking service
+-     Start time: 2024-06-20 09:00:00.001550+00:00
+-     Version: 2729a
+-     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+- STARTING Tracking service
+-     Start time: 2024-06-20 09:00:00.001550+00:00
+-     Version: 2729a
+-     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+- STARTING Tracking service
+-     Start time: 2024-06-21 09:00:00.001550+00:00
+-     Version: 2729a
+-     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+
+>>>>>>>>>> a report has been reported <<<<<<<<<<
+
+Number of error lines: 22
+
+Duplicate Log Messages:
+instrument not found for ric UYU.T
+Could not find instrument for sedol OIN38378, trying ric 837.RIJ
+prometheus client http server running
+instrument not found for sedol RZZZZ2
+Caught exception N/A. Message: Unclosed connector NoneType: None
+20 05:00:00+00:00 on topic internal from kafka.servers:9092
+tracking_service Closed
+instrument not found for ric RUE.ST
+version', '2729a']
+Version: 2729a
+Could not find instrument for ric YT.ATS, using provided identifier 1
+Adding subscription for pid None
+Kafka source starting for topic internal at current offset 7924032 end offset 7928950 on servers kafka.servers:9092
+20 09:00:00.001550+00:00
+Could not find instrument for sedol UY29387, trying ric RUE.ST
+Could not find instrument for ric RUE.ST, using provided identifier 5
 ====================================================
+market hours frequency
+Closing client connection.
 STARTING Tracking service
-    Start time: 2024-06-20 09:00:00.001550+00:00
-    Version: 2729a
-    Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
-====================================================
-2024-06-20 11:00:17,983 - root - INFO - Adding subscription for pid None
-2024-06-20 11:00:18,115 - root - INFO - Initialized Influx DB Client to host
-2024-06-20 11:00:18,115 - root - INFO - Scheduling Error Handler in 150.0 seconds
-2024-06-20 11:00:18,116 - root - INFO - prometheus client http server running
-2024-06-20 11:00:18,172 - root - INFO - Initialized prometheus server.
-2024-06-20 11:00:18,172 - root - INFO - reading messages from 2024-06-20
-2024-06-20 11:00:18,172 - aiokafka.consumer.subscription_state - INFO - Updating subscribed topics to: frozenset({'internal'})
-2024-06-20 11:00:18,185 - root - INFO - Kafka reading from start of day 2024-06-20 05:00:00+00:00 on topic internal from kafka.servers:9092
-2024-06-20 11:00:19,328 - root - INFO - Kafka source starting for topic internal at current offset 7924032 end offset 7928950 on servers kafka.servers:9092
-2024-06-20 11:00:22,329 - root - INFO - Kafka topic internal is caught up at offset 7928949
-2024-06-20 11:00:22,329 - root - INFO - setting influx write rate to pre-market hours frequency
-2024-06-20 11:00:22,329 - root - INFO - Tracking service is caught up
-2024-06-20 11:40:43,527 - root - WARNING - instrument not found for sedol BYP321337
-2024-06-20 11:40:43,527 - root - WARNING - Could not find instrument for sedol BYP321337, trying ric YT.ATS
-2024-06-20 11:40:43,527 - root - WARNING - instrument not found for ric YT.ATS
-2024-06-20 11:40:43,527 - root - WARNING - Could not find instrument for ric YT.ATS, using provided identifier 1
-2024-06-20 11:40:43,527 - root - WARNING - instrument not found for sedol DHI7337
-2024-06-20 11:40:43,527 - root - WARNING - Could not find instrument for sedol DHI7337, trying ric YT.ATS
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric JPQ.CC
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric JPQ.CC, using provided identifier 2
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for sedol RZZZZ2
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for sedol RZZZZ2, trying ric UYU.T
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric UYU.T
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric UTU.T, using provided identifier 3
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for sedol OIN38378
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for sedol OIN38378, trying ric 837.RIJ
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric 837.RIJ
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric 837.RIJ, using provided identifier 4
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for sedol UY29387
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for sedol UY29387, trying ric RUE.ST
-2024-06-20 11:40:43,529 - root - WARNING - instrument not found for ric RUE.ST
-2024-06-20 11:40:43,529 - root - WARNING - Could not find instrument for ric RUE.ST, using provided identifier 5
-2024-06-20 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-20 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed connector NoneType: None
-2024-06-20 17:17:04,278 - root - INFO - Updating prices
-2024-06-20 17:24:34,091 - root - INFO - Closing client connection.
-2024-06-20 17:24:34,092 - root - INFO - Client (0)ui-tracking_service Closed
-2024-06-20 17:25:08,029 - root - ERROR - Exception in message handler <bound method TrackingService.method of <app.tracking_service.TrackingService object at 0x7feba0d0>> TrackingService.on_order_change() missing 1 required positional argument: 'order_identifier'
-====================================================
-STARTING Tracking service
-    Start time: 2024-06-21 09:00:00.001550+00:00
-    Version: 2729a
-    Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
-====================================================
-2024-06-21 11:00:17,983 - root - INFO - Adding subscription for pid None
-2024-06-21 11:00:18,115 - root - INFO - Initialized Influx DB Client to host
-2024-06-21 11:00:18,115 - root - INFO - Scheduling Error Handler in 150.0 seconds
-2024-06-21 11:00:18,116 - root - INFO - prometheus client http server running
-2024-06-21 11:00:18,172 - root - INFO - Initialized prometheus server.
-2024-06-21 11:00:18,172 - root - INFO - reading messages from 2024-06-20
-2024-06-21 11:00:18,172 - root - INFO - reading messages from 2024-06-20
-2024-06-21 11:00:18,172 - root - INFO - reading messages from 2024-06-20
-2024-06-21 11:00:18,172 - root - INFO - reading messages from 2024-06-20
-2024-06-21 11:00:18,172 - aiokafka.consumer.subscription_state - INFO - Updating subscribed topics to: frozenset({'internal'})
-2024-06-21 11:00:18,185 - root - INFO - Kafka reading from start of day 2024-06-20 05:00:00+00:00 on topic internal from kafka.servers:9092
-2024-06-21 11:00:19,328 - root - INFO - Kafka source starting for topic internal at current offset 7924032 end offset 7928950 on servers kafka.servers:9092
-2024-06-21 11:00:22,329 - root - INFO - Kafka topic internal is caught up at offset 7928949
-2024-06-21 11:00:22,329 - root - INFO - setting influx write rate to pre-market hours frequency
-2024-06-21 11:00:22,329 - root - INFO - Tracking service is caught up
-2024-06-21 11:40:43,527 - root - WARNING - instrument not found for sedol BYP321337
-2024-06-21 11:40:43,527 - root - WARNING - Could not find instrument for sedol BYP321337, trying ric YT.ATS
-2024-06-21 11:40:43,527 - root - WARNING - instrument not found for ric YT.ATS
-2024-06-21 11:40:43,527 - root - WARNING - Could not find instrument for ric YT.ATS, using provided identifier 1
-2024-06-21 11:40:43,527 - root - WARNING - instrument not found for sedol DHI7337
-2024-06-21 11:40:43,527 - root - WARNING - Could not find instrument for sedol DHI7337, trying ric YT.ATS
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for ric JPQ.CC
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for ric JPQ.CC, using provided identifier 2
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for sedol RZZZZ2
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for sedol RZZZZ2, trying ric UYU.T
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for ric UYU.T
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for ric UTU.T, using provided identifier 3
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for sedol OIN38378
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for sedol OIN38378, trying ric 837.RIJ
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for ric 837.RIJ
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for ric 837.RIJ
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for ric 837.RIJ, using provided identifier 4
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for ric 837.RIJ, using provided identifier 4
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for sedol UY29387
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for sedol UY29387, trying ric RUE.ST
-2024-06-21 11:40:43,529 - root - WARNING - instrument not found for ric RUE.ST
-2024-06-21 11:40:43,529 - root - WARNING - Could not find instrument for ric RUE.ST, using provided identifier 5
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed client session NoneType: None
-2024-06-21 17:16:03,660 - root - ERROR - Caught exception N/A. Message: Unclosed connector NoneType: None
-2024-06-21 17:17:04,278 - root - INFO - Updating prices
-2024-06-21 17:24:34,091 - root - INFO - Closing client connection.
-2024-06-21 17:24:34,092 - root - INFO - Client (0)ui-tracking_service Closed
-2024-06-21 17:25:08,029 - root - ERROR - Exception in message handler <bound method TrackingService.method of <app.tracking_service.TrackingService object at 0x7feba0d0>> TrackingService.on_order_change() missing 1 required positional argument: 'order_identifier'Number of error lines: 22Number of log lines: 151Number of info messages: 0
+instrument not found for ric 837.RIJ
+Updating subscribed topics to: frozenset({'internal'})
+instrument not found for sedol OIN38378
+Initialized prometheus server.
+Could not find instrument for ric 837.RIJ, using provided identifier 4
+Tracking service is caught up
+Exception in message handler <bound method TrackingService.method of <app.tracking_service.TrackingService object at 0x7feba0d0>> TrackingService.on_order_change() missing 1 required positional argument: 'order_identifier'
+20
+Scheduling Error Handler in 150.0 seconds
+Updating prices
+instrument not found for ric JPQ.CC
+Initialized Influx DB Client to host
+instrument not found for sedol BYP321337
+Could not find instrument for sedol DHI7337, trying ric YT.ATS
+Could not find instrument for ric JPQ.CC, using provided identifier 2
+instrument not found for sedol DHI7337
+Could not find instrument for sedol RZZZZ2, trying ric UYU.T
+instrument not found for ric YT.ATS
+Could not find instrument for sedol BYP321337, trying ric YT.ATS
+Could not find instrument for ric UTU.T, using provided identifier 3
+Caught exception N/A. Message: Unclosed client session NoneType: None
+Kafka topic internal is caught up at offset 7928949
+instrument not found for sedol UY29387
+
+Number of log lines: 151
+
+Lines that do not conform to log format:
+- Hello I am a bad log line
+
+Lines that are part of the startup header:
+- STARTING Tracking service
+-     Start time: 2024-06-20 09:00:00.001550+00:00
+-     Version: 2729a
+-     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+- STARTING Tracking service
+-     Start time: 2024-06-20 09:00:00.001550+00:00
+-     Version: 2729a
+-     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+- STARTING Tracking service
+-     Start time: 2024-06-21 09:00:00.001550+00:00
+-     Version: 2729a
+-     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
+
+>>>>>>>>>> a report has been reported <<<<<<<<<<

--- a/src/alogamous/__main__.py
+++ b/src/alogamous/__main__.py
@@ -9,6 +9,7 @@ from alogamous import (
     line_count_analyzer,
     log_line_parser,
     loginfo_analyzer,
+    stack_trace_analyzer,
     startup_header_analyzer,
     warning_analyzer,
 )
@@ -44,6 +45,7 @@ with open(f"{sys.argv[3]}", "a") as output_file:
             format_analyzer.FormatAnalyzer(line_parser),
             warning_analyzer.WarningAnalyzer(),
             loginfo_analyzer.InfoAnalyzer(line_parser),
+            stack_trace_analyzer.StackTraceAnalyzer(line_parser),
             startup_header_analyzer.StartupHeaderAnalyzer(line_parser),
             warning_analyzer.WarningAnalyzer(),
         ],

--- a/src/alogamous/analyzer.py
+++ b/src/alogamous/analyzer.py
@@ -17,4 +17,5 @@ def analyze_log_stream(analyzers, in_stream, out_stream):
             analyzer.read_log_line(line.rstrip())
     for analyzer in analyzers:
         analyzer.report(out_stream)
-        out_stream.write("\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n")
+        out_stream.write("\n\n")
+    out_stream.write(">>>>>>>>>> a report has been reported <<<<<<<<<<\n\n")

--- a/src/alogamous/flag_duplicate_log_messages.py
+++ b/src/alogamous/flag_duplicate_log_messages.py
@@ -16,7 +16,6 @@ class FlagDuplicateLogMessages(analyzer.Analyzer):
     def report(self, out_stream):
         if len(self.duplicateMessages) > 0:
             out_stream.write("Duplicate Log Messages:\n")
-            for message in self.duplicateMessages:
-                out_stream.write(f"{message}\n")
+            out_stream.write("\n".join(self.duplicateMessages))
         else:
-            out_stream.write("No duplicate log messages\n")
+            out_stream.write("No duplicate log messages")

--- a/src/alogamous/format_analyzer.py
+++ b/src/alogamous/format_analyzer.py
@@ -5,11 +5,17 @@ class FormatAnalyzer(analyzer.Analyzer):
     def __init__(self, line_parser):
         self.parser = line_parser
         self.startup_block = False
+        self.stack_trace = False
         self.un_formated_lines = []
 
     def read_log_line(self, line):
         line_type = self.parser.parse(line)["type"]
-        if self.startup_block is False:
+        if line.count("Traceback") == 1:
+            self.stack_trace = True
+        elif self.stack_trace:
+            if line_type == (log_line_parser.LineType.LOG_LINE or log_line_parser.LineType.HEADER_LINE):
+                self.stack_trace = False
+        elif self.startup_block is False and self.stack_trace is False:
             if line_type == log_line_parser.LineType.UNSTRUCTURED_LINE:
                 self.un_formated_lines.append(line)
             elif line_type == log_line_parser.LineType.HEADER_LINE:

--- a/src/alogamous/format_analyzer.py
+++ b/src/alogamous/format_analyzer.py
@@ -25,7 +25,7 @@ class FormatAnalyzer(analyzer.Analyzer):
 
     def report(self, out_stream):
         if self.un_formated_lines:
-            out_stream.write("\nLines that do not conform to log format:\n- ")
+            out_stream.write("Lines that do not conform to log format:\n- ")
             out_stream.write("\n- ".join(self.un_formated_lines))
         else:
             out_stream.write("All lines conform to log line format")

--- a/src/alogamous/stack_trace_analyzer.py
+++ b/src/alogamous/stack_trace_analyzer.py
@@ -1,0 +1,32 @@
+from alogamous import analyzer, log_line_parser
+
+
+class StackTraceAnalyzer(analyzer.Analyzer):
+    def __init__(self, line_parser):
+        self.parser = line_parser
+        self.stack_trace = False
+        self.stack_trace_counter = 0
+        self.stack_trace_lines = []
+        self.non_fatal_trace = False
+
+    def read_log_line(self, line):
+        line_type = self.parser.parse(line)["type"]
+        if line_type == log_line_parser.LineType.UNSTRUCTURED_LINE and line.count("Traceback") == 1:
+            self.stack_trace = True
+            self.stack_trace_counter += 1
+            self.stack_trace_lines.append(line)
+        elif self.stack_trace:
+            if line_type == log_line_parser.LineType.UNSTRUCTURED_LINE:
+                self.stack_trace_lines.append(line)
+            elif line_type == log_line_parser.LineType.HEADER_LINE:
+                self.stack_trace = False
+            elif line_type == log_line_parser.LineType.LOG_LINE:
+                self.stack_trace = False
+                self.non_fatal_trace = True
+
+    def report(self, out_stream):
+        if self.non_fatal_trace:
+            out_stream.write(f"{self.stack_trace_counter} non-fatal stack trace(s) found:\n- ")
+            out_stream.write("\n- ".join(self.stack_trace_lines))
+        else:
+            out_stream.write("No non-fatal stack traces were found")

--- a/src/alogamous/startup_header_analyzer.py
+++ b/src/alogamous/startup_header_analyzer.py
@@ -18,5 +18,5 @@ class StartupHeaderAnalyzer(analyzer.Analyzer):
                 self.startup_block = False
 
     def report(self, out_stream):
-        out_stream.write("\nLines that are part of the startup header(s):\n- ")
+        out_stream.write("Lines that are part of the startup header(s):\n- ")
         out_stream.write("\n- ".join(self.startup_lines))

--- a/src/alogamous/warning_analyzer.py
+++ b/src/alogamous/warning_analyzer.py
@@ -13,8 +13,8 @@ class WarningAnalyzer(analyzer.Analyzer):
 
     def report(self, out_stream):
         if self.count == 0:
-            out_stream.write("\n" + "No Warnings were detected.")
+            out_stream.write("No Warnings were detected.")
         elif self.count == 1:
-            out_stream.write("\n" + "1 Warning was detected.")
+            out_stream.write("1 Warning was detected.")
         else:
-            out_stream.write("\n" + str(self.count) + " Warnings were detected.")
+            out_stream.write(str(self.count) + " Warnings were detected.")

--- a/tests/analyze_log_stream_test.py
+++ b/tests/analyze_log_stream_test.py
@@ -26,7 +26,4 @@ def test_analyze_log_stream():
     out_stream = io.StringIO()
 
     analyzer.analyze_log_stream([TestAnalyzer1(), TestAnalyzer2()], in_stream, out_stream)
-    assert (
-        out_stream.getvalue()
-        == "\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n"
-    )
+    assert out_stream.getvalue() == "\n\n\n\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n\n"

--- a/tests/flag_duplicate_log_messages_test.py
+++ b/tests/flag_duplicate_log_messages_test.py
@@ -12,7 +12,7 @@ def test_flag_duplicate_log_messages():
     for line in in_stream:
         flagger.read_log_line(line)
     flagger.report(out_stream)
-    assert out_stream.getvalue() == """Duplicate Log Messages:\nlog message 1\n"""
+    assert out_stream.getvalue() == """Duplicate Log Messages:\nlog message 1"""
 
 
 def test_flag_duplicate_log_messages_no_duplicates():
@@ -24,4 +24,4 @@ def test_flag_duplicate_log_messages_no_duplicates():
     for line in in_stream:
         flagger.read_log_line(line)
     flagger.report(out_stream)
-    assert out_stream.getvalue() == """No duplicate log messages\n"""
+    assert out_stream.getvalue() == """No duplicate log messages"""

--- a/tests/format_analyzer_test.py
+++ b/tests/format_analyzer_test.py
@@ -53,3 +53,52 @@ def test_format_analyzer_with_good_lines():
         format_checker.read_log_line(line)
     format_checker.report(out_stream)
     assert out_stream.getvalue() == "All lines conform to log line format"
+
+
+def test_format_with_stack_trace():
+    parser = log_line_parser.LogLineParser(
+        ["datetime", "source", "level", "message"], " - ", "===================================================="
+    )
+    format_checker = format_analyzer.FormatAnalyzer(parser)
+    in_stream = """2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+Hello I am a bad log line
+2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+Traceback (most recent call last):
+  File "<frozen runpy>", line 1938, in _run_module_as_main
+  File "<frozen runpy>", line 88, in _run_code
+  File ".build/2811/execution/execution_service", line 973, in <module>
+    app.run(life_cycle_runner.run, life_cycle_runner.stop)
+  File ".build/2811/app/application.py", line 219, in run
+    run(self.start(my_date, main, stop))
+  File ".build/2811/.venv/lib/python3.11/runners.py", line 190, in run
+    return runner.run(main)
+           ^^^^^^^^^^^^^^^^
+  File ".build/2811/.venv/lib/python3.11/runners.py", line 118, in run
+    return self._loop.run_until_complete(task)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ".build/2811/.venv/lib/python3.11/events.py", line 653, in run_until_done
+    return future.result()
+           ^^^^^^^^^^^^^^^
+  File "2811/app/application.py", line 421, in start
+    await self.task
+  File "2811/messages/app/runner.py", line 449, in run
+    await asyncio.gather(*self.running_tasks)
+  File "2811/messages/processor.py", line 340, in run
+    await self.dispatch(message)
+  File ".build/2811/execution/execution_service", line 1315, in market_test
+    if symbol and obj.region != 'NORTHAMERICA'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: 'NoneType' object has no attribute 'region'
+2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+Hello I am a bad log line"""
+    out_stream = StringIO()
+    for line in in_stream.splitlines():
+        format_checker.read_log_line(line)
+    format_checker.report(out_stream)
+    assert (
+        out_stream.getvalue()
+        == """
+Lines that do not conform to log format:
+- Hello I am a bad log line
+- Hello I am a bad log line"""
+    )

--- a/tests/format_analyzer_test.py
+++ b/tests/format_analyzer_test.py
@@ -26,8 +26,7 @@ Hello I am a bad log line"""
     format_checker.report(out_stream)
     assert (
         out_stream.getvalue()
-        == """
-Lines that do not conform to log format:
+        == """Lines that do not conform to log format:
 - Hello I am a bad log line
 - Hello I am a bad log line"""
     )

--- a/tests/format_analyzer_test.py
+++ b/tests/format_analyzer_test.py
@@ -96,8 +96,7 @@ Hello I am a bad log line"""
     format_checker.report(out_stream)
     assert (
         out_stream.getvalue()
-        == """
-Lines that do not conform to log format:
+        == """Lines that do not conform to log format:
 - Hello I am a bad log line
 - Hello I am a bad log line"""
     )

--- a/tests/stack_trace_analyzer_test.py
+++ b/tests/stack_trace_analyzer_test.py
@@ -1,0 +1,127 @@
+from io import StringIO
+
+from alogamous import log_line_parser, stack_trace_analyzer
+
+
+def test_stacktrace_where_service_dies():
+    parser = log_line_parser.LogLineParser(
+        ["datetime", "source", "level", "message"], " - ", "===================================================="
+    )
+    stacktrace_checker = stack_trace_analyzer.StackTraceAnalyzer(parser)
+    in_stream = """2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+Traceback (most recent call last):
+  File "<frozen runpy>", line 1938, in _run_module_as_main
+  File "<frozen runpy>", line 88, in _run_code
+  File ".build/2811/execution/execution_service", line 973, in <module>
+    app.run(life_cycle_runner.run, life_cycle_runner.stop)
+  File ".build/2811/app/application.py", line 219, in run
+    run(self.start(my_date, main, stop))
+  File ".build/2811/.venv/lib/python3.11/runners.py", line 190, in run
+    return runner.run(main)
+           ^^^^^^^^^^^^^^^^
+  File ".build/2811/.venv/lib/python3.11/runners.py", line 118, in run
+    return self._loop.run_until_complete(task)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ".build/2811/.venv/lib/python3.11/events.py", line 653, in run_until_done
+    return future.result()
+           ^^^^^^^^^^^^^^^
+  File "2811/app/application.py", line 421, in start
+    await self.task
+  File "2811/messages/app/runner.py", line 449, in run
+    await asyncio.gather(*self.running_tasks)
+  File "2811/messages/processor.py", line 340, in run
+    await self.dispatch(message)
+  File ".build/2811/execution/execution_service", line 1315, in market_test
+    if symbol and obj.region != 'NORTHAMERICA'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: 'NoneType' object has no attribute 'region'"""
+    out_stream = StringIO()
+    for line in in_stream.splitlines():
+        stacktrace_checker.read_log_line(line)
+    stacktrace_checker.report(out_stream)
+    assert out_stream.getvalue() == "No non-fatal stack traces were found"
+
+
+def test_stacktrace_where_service_lives():
+    parser = log_line_parser.LogLineParser(
+        ["datetime", "source", "level", "message"], " - ", "===================================================="
+    )
+    stacktrace_checker = stack_trace_analyzer.StackTraceAnalyzer(parser)
+    in_stream = """2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+Traceback (most recent call last):
+  File "<frozen runpy>", line 1938, in _run_module_as_main
+  File "<frozen runpy>", line 88, in _run_code
+  File ".build/2811/execution/execution_service", line 973, in <module>
+    app.run(life_cycle_runner.run, life_cycle_runner.stop)
+  File ".build/2811/app/application.py", line 219, in run
+    run(self.start(my_date, main, stop))
+  File ".build/2811/.venv/lib/python3.11/runners.py", line 190, in run
+    return runner.run(main)
+           ^^^^^^^^^^^^^^^^
+  File ".build/2811/.venv/lib/python3.11/runners.py", line 118, in run
+    return self._loop.run_until_complete(task)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File ".build/2811/.venv/lib/python3.11/events.py", line 653, in run_until_done
+    return future.result()
+           ^^^^^^^^^^^^^^^
+  File "2811/app/application.py", line 421, in start
+    await self.task
+  File "2811/messages/app/runner.py", line 449, in run
+    await asyncio.gather(*self.running_tasks)
+  File "2811/messages/processor.py", line 340, in run
+    await self.dispatch(message)
+  File ".build/2811/execution/execution_service", line 1315, in market_test
+    if symbol and obj.region != 'NORTHAMERICA'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: 'NoneType' object has no attribute 'region'
+2024-07-23 21:13:54,091 - root - ERROR - Caught exception N/A. Message: Unclosed client session"""
+    out_stream = StringIO()
+    for line in in_stream.splitlines():
+        stacktrace_checker.read_log_line(line)
+    stacktrace_checker.report(out_stream)
+    assert (
+        out_stream.getvalue()
+        == """1 non-fatal stack trace(s) found:
+- Traceback (most recent call last):
+-   File "<frozen runpy>", line 1938, in _run_module_as_main
+-   File "<frozen runpy>", line 88, in _run_code
+-   File ".build/2811/execution/execution_service", line 973, in <module>
+-     app.run(life_cycle_runner.run, life_cycle_runner.stop)
+-   File ".build/2811/app/application.py", line 219, in run
+-     run(self.start(my_date, main, stop))
+-   File ".build/2811/.venv/lib/python3.11/runners.py", line 190, in run
+-     return runner.run(main)
+-            ^^^^^^^^^^^^^^^^
+-   File ".build/2811/.venv/lib/python3.11/runners.py", line 118, in run
+-     return self._loop.run_until_complete(task)
+-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-   File ".build/2811/.venv/lib/python3.11/events.py", line 653, in run_until_done
+-     return future.result()
+-            ^^^^^^^^^^^^^^^
+-   File "2811/app/application.py", line 421, in start
+-     await self.task
+-   File "2811/messages/app/runner.py", line 449, in run
+-     await asyncio.gather(*self.running_tasks)
+-   File "2811/messages/processor.py", line 340, in run
+-     await self.dispatch(message)
+-   File ".build/2811/execution/execution_service", line 1315, in market_test
+-     if symbol and obj.region != 'NORTHAMERICA'
+-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- AttributeError: 'NoneType' object has no attribute 'region'"""
+    )
+
+
+def test_no_stacktrace():
+    parser = log_line_parser.LogLineParser(
+        ["datetime", "source", "level", "message"], " - ", "===================================================="
+    )
+    stacktrace_checker = stack_trace_analyzer.StackTraceAnalyzer(parser)
+    in_stream = """2024-07-23 21:13:53,862 - root - INFO - Closing client connection.
+    2024-07-23 21:13:53,862 - root - INFO - Closing client connection."""
+    out_stream = StringIO()
+    for line in in_stream.splitlines():
+        stacktrace_checker.read_log_line(line)
+    stacktrace_checker.report(out_stream)
+    assert out_stream.getvalue() == "No non-fatal stack traces were found"

--- a/tests/startup_header_analyzer_test.py
+++ b/tests/startup_header_analyzer_test.py
@@ -23,8 +23,7 @@ STARTING Tracking service
     startup_analyzer.report(out_stream)
     assert (
         out_stream.getvalue()
-        == """
-Lines that are part of the startup header(s):
+        == """Lines that are part of the startup header(s):
 - STARTING Tracking service
 -     Start time: 2024-06-20 09:00:00.001550+00:00
 -     Version: 2729a

--- a/tests/warning_analyzer_test.py
+++ b/tests/warning_analyzer_test.py
@@ -17,4 +17,4 @@ def test_warning_count():
     for line in in_stream:
         counter.read_log_line(line)
     counter.report(out_stream)
-    assert out_stream.getvalue() == "\n2 Warnings were detected."
+    assert out_stream.getvalue() == "2 Warnings were detected."


### PR DESCRIPTION
Closes #73

I added more logic to stop the format analyzer from flagging stack traces. I also merged in the added newlines in `analyze_log_stream` and the necessary changes to analyzer to make that compatible, so that hopefully there won't be merge conflicts.