### PR TITLE
Use different characters to denote reports to avoid weird doc string …

### DIFF
--- a/data/test_output_file.txt
+++ b/data/test_output_file.txt
@@ -64,7 +64,7 @@ Lines that are part of the startup header:
 -     Version: 2729a
 -     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
 
->>>>>>>>>> a report has been reported <<<<<<<<<<
+------ a report has been reported ------
 
 Number of error lines: 22
 
@@ -132,4 +132,4 @@ Lines that are part of the startup header:
 -     Version: 2729a
 -     Command line: ['.venv/bin/python3', '-m', 'app.tracking_service', '--market', 'US', '--version', '2729a']
 
->>>>>>>>>> a report has been reported <<<<<<<<<<
+------ a report has been reported ------

--- a/src/alogamous/analyzer.py
+++ b/src/alogamous/analyzer.py
@@ -18,4 +18,4 @@ def analyze_log_stream(analyzers, in_stream, out_stream):
     for analyzer in analyzers:
         analyzer.report(out_stream)
         out_stream.write("\n\n")
-    out_stream.write(">>>>>>>>>> a report has been reported <<<<<<<<<<\n\n")
+    out_stream.write("------ a report has been reported ------\n\n")

--- a/tests/analyze_log_stream_test.py
+++ b/tests/analyze_log_stream_test.py
@@ -26,4 +26,4 @@ def test_analyze_log_stream():
     out_stream = io.StringIO()
 
     analyzer.analyze_log_stream([TestAnalyzer1(), TestAnalyzer2()], in_stream, out_stream)
-    assert out_stream.getvalue() == "\n\n\n\n>>>>>>>>>> a report has been reported <<<<<<<<<<\n\n"
+    assert out_stream.getvalue() == "\n\n\n\n------ a report has been reported ------\n\n"


### PR DESCRIPTION
…error.