### PR TITLE
Fixing hatch format error

### DIFF
--- a/src/alogamous/daily_warning_analyzer.py
+++ b/src/alogamous/daily_warning_analyzer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 from alogamous import analyzer, log_line_parser


### PR DESCRIPTION
Somehow, changes got committed that broke the pre-commit hooks

```
brady ~/benrady-src/alogamous (find-peaktimes) [0s]% git commit
[INFO] Checking merge-conflict files only.
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for added large files..............................................Passed
mixed line ending........................................................Passed
detect private key.......................................................Passed
check for merge conflicts................................................Passed
pyupgrade................................................................Passed
autoflake................................................................Passed
hatch fmt................................................................Failed
- hook id: fmt
- exit code: 1

src/alogamous/daily_warning_analyzer.py:8:31: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
src/alogamous/daily_warning_analyzer.py:8:41: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
src/alogamous/daily_warning_analyzer.py:9:36: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
src/alogamous/daily_warning_analyzer.py:9:46: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
```